### PR TITLE
Push attributes from task payloads to MWDB

### DIFF
--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, cast
 
 from karton.core import Karton, RemoteResource, Task
 from mwdblib import MWDB, MWDBBlob, MWDBConfig, MWDBFile, MWDBObject
+from mwdblib.api.options import APIClientOptions
 
 from .__version__ import __version__
 
@@ -30,7 +31,7 @@ class MWDBReporter(Karton):
     }
     ```
 
-    Samples are decorated with tag: `kind:platform:extension` or `misc:kind` if platform is missing
+    Samples are decorated with tag: ``kind:platform:extension`` or ``misc:kind`` if platform is missing
 
     Expected incoming task structure for configs:
     ```
@@ -63,7 +64,7 @@ class MWDBReporter(Karton):
         mwdb_config = dict(self.config.config.items("mwdb"))
         mwdb = MWDB(
             api_key=mwdb_config.get("api_key"),
-            api_url=mwdb_config.get("api_url"),
+            api_url=mwdb_config.get("api_url", APIClientOptions.api_url),
             retry_on_downtime=True,
         )
         if not mwdb.api.auth_token:
@@ -187,8 +188,8 @@ class MWDBReporter(Karton):
     def _add_metakey(self, mwdb_object: MWDBObject, key: str, value: str) -> None:
         """
         Add a metakey to passed object.
-        `add_metakey` is deprecated but we use it here to keep compatibility with
-        MWDB instances that do not yet expose the `attribute` endpoint
+        ``add_metakey`` is deprecated but we use it here to keep compatibility with
+        MWDB instances that do not yet expose the "attribute" endpoint
 
         :param mwdb_object: MWDBObject instance
         :param key: Metakey name
@@ -205,15 +206,13 @@ class MWDBReporter(Karton):
             )
             mwdb_object.add_metakey(key, value)
 
-    def _add_attribute(
-        self, mwdb_object: MWDBObject, key: str, value: Dict[str, Any]
-    ) -> None:
+    def _add_attribute(self, mwdb_object: MWDBObject, key: str, value: Any) -> None:
         """
         Add a attribute to passed object.
 
         :param mwdb_object: MWDBObject instance
         :param key: Attribute name
-        :param value: Attribute value
+        :param value: Attribute value, must be JSONable
         """
 
         if value not in mwdb_object.attributes.get(key, []):

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -206,7 +206,9 @@ class MWDBReporter(Karton):
             )
             mwdb_object.add_metakey(key, value)
 
-    def _add_attribute(self, mwdb_object: MWDBObject, key: str, value: Dict[str, Any]) -> None:
+    def _add_attribute(
+        self, mwdb_object: MWDBObject, key: str, value: Dict[str, Any]
+    ) -> None:
         """
         Add a attribute to passed object.
 
@@ -321,7 +323,9 @@ class MWDBReporter(Karton):
                         # this is kept for compatibility with older mwdb-core instances
                         self._add_metakey(mwdb_object=mwdb_object, key=key, value=value)
                     else:
-                        self._add_attribute(mwdb_object=mwdb_object, key=key, value=value)
+                        self._add_attribute(
+                            mwdb_object=mwdb_object, key=key, value=value
+                        )
 
         # Add payload comments
         comments = task.get_payload("comments") or task.get_payload("additional_info")

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Optional, cast
 
 from karton.core import Karton, RemoteResource, Task
 from mwdblib import MWDB, MWDBBlob, MWDBConfig, MWDBFile, MWDBObject
-from mwdblib.api import API_URL
 
 from .__version__ import __version__
 
@@ -64,10 +63,10 @@ class MWDBReporter(Karton):
         mwdb_config = dict(self.config.config.items("mwdb"))
         mwdb = MWDB(
             api_key=mwdb_config.get("api_key"),
-            api_url=mwdb_config.get("api_url", API_URL),
+            api_url=mwdb_config.get("api_url"),
             retry_on_downtime=True,
         )
-        if not mwdb.api.api_key:
+        if not mwdb.api.auth_token:
             mwdb.login(mwdb_config["username"], mwdb_config["password"])
         return mwdb
 
@@ -106,7 +105,7 @@ class MWDBReporter(Karton):
 
         self.log.info("[sample %s] Querying for sample", dhash)
 
-        file = mwdb.query_file(dhash, raise_not_found=False)
+        file = mwdb.query_file(dhash, raise_not_found=False)  # type: ignore
         if file is not None:
             self.log.info("[sample %s] Sample already exists", dhash)
 
@@ -199,7 +198,7 @@ class MWDBReporter(Karton):
         if value not in mwdb_object.metakeys.get(key, []):
             self.log.info(
                 "[%s %s] Adding metakey %s: %s",
-                mwdb_object.type,
+                mwdb_object.TYPE,
                 mwdb_object.id,
                 key,
                 value,
@@ -220,7 +219,7 @@ class MWDBReporter(Karton):
         if value not in mwdb_object.attributes.get(key, []):
             self.log.info(
                 "[%s %s] Adding attribute %s: %s",
-                mwdb_object.type,
+                mwdb_object.TYPE,
                 mwdb_object.id,
                 key,
                 value,
@@ -311,7 +310,7 @@ class MWDBReporter(Karton):
             for tag in task.get_payload("tags"):
                 if tag not in mwdb_object.tags:
                     self.log.info(
-                        "[%s %s] Adding tag %s", mwdb_object.type, mwdb_object.id, tag
+                        "[%s %s] Adding tag %s", mwdb_object.TYPE, mwdb_object.id, tag
                     )
                     mwdb_object.add_tag(tag)
 
@@ -333,7 +332,7 @@ class MWDBReporter(Karton):
             for comment in comments:
                 self.log.info(
                     "[%s %s] Adding comment: %s",
-                    mwdb_object.type,
+                    mwdb_object.TYPE,
                     mwdb_object.id,
                     repr(comment),
                 )

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -212,7 +212,7 @@ class MWDBReporter(Karton):
 
         :param mwdb_object: MWDBObject instance
         :param key: Attribute name
-        :param value: Attribute value, must be JSONable
+        :param value: Attribute value, must be JSON-serializable
         """
 
         if value not in mwdb_object.attributes.get(key, []):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mwdblib==3.4.0
+mwdblib>=4.0.0
 karton-core>=4.2.0,<5.0.0


### PR DESCRIPTION
MWDB now supports JSON-like attributes (formely metakeys).

This PR enables the reporter to pass the new attributes to MWDB while maintaining compatibility with older versions of MWDB