### PR TITLE
Fix: Use 'kind' instead of 'blob_type'

### DIFF
--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -58,7 +58,7 @@ class MWDBReporter(Karton):
     {
         "headers": {
             "type": "blob",
-            "blob_type": <blob type>
+            "kind": <blob type>
         },
         "payload": {
             "name": String with blob name
@@ -508,8 +508,8 @@ class MWDBReporter(Karton):
 
         self._upload_blob(
             task,
-            blob_name=task.get_payload("name"),
-            blob_type=task.headers["blob_type"],
+            blob_name=task.get_payload("name", default="blob"),
+            blob_type=task.headers["kind"],
             content=task.get_payload("blob"),
             parent=parent,
             tags=task.get_payload("tags", []),


### PR DESCRIPTION
Already existing implementation of blob reporting in MWDB uses different name of field that stores blob type:

https://github.com/CERT-Polska/mwdb-core/blob/0c2703da35436b7124ade36f75457dd17739e324/mwdb/core/karton.py#L82-L95
```python
def send_blob_to_karton(blob) -> str:
    producer = get_karton_producer()
    task = Task(
        headers={"type": "blob", "kind": blob.blob_type},
        payload={
            "content": blob.content,
            "dhash": blob.dhash,
            "attributes": blob.get_attributes(as_dict=True, check_permissions=False),
        },
    )
    producer.send_task(task)

    logger.info("Blob sent to Karton with %s", task.root_uid)
    return task.root_uid
```

As blob support is not yet included in stable release of karton-mwdb-reporter, we decided to make a change compatible with existing implementation in MWDB.