### PR TITLE
WIP: Prepare for karton5 migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 WORKDIR /app/service
 COPY ./requirements.txt ./requirements.txt

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -84,7 +84,7 @@ class MWDBReporter(Karton):
     MAX_FILE_SIZE = 1024 * 1024 * 40
 
     def _get_mwdb(self) -> MWDB:
-        mwdb_config = dict(self.config.config.items("mwdb"))
+        mwdb_config = self.config["mwdb"]
         mwdb = MWDB(
             api_key=mwdb_config.get("api_key"),
             api_url=mwdb_config.get("api_url", APIClientOptions.api_url),

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -518,7 +518,7 @@ class MWDBReporter(Karton):
             or task.get_payload("additional_info", []),
         )
 
-    def process(self, task: Task) -> None:  # type: ignore
+    def process(self, task: Task) -> None:
         object_type = task.headers["type"]
         mwdb_object: Optional[MWDBObject]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mwdblib>=4.1.0
-karton-core>=4.2.0,<5.0.0
+karton-core>=5.0.0,<6.0.0


### PR DESCRIPTION
Due to the change of how KartonConfig works (https://github.com/CERT-Polska/karton/pull/176) we no longer have to grab it through several layers of objects.