### PR TITLE
Provide credentials via args instead of login

### DIFF
--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -88,10 +88,12 @@ class MWDBReporter(Karton):
         mwdb = MWDB(
             api_key=mwdb_config.get("api_key"),
             api_url=mwdb_config.get("api_url", APIClientOptions.api_url),
+            username=mwdb_config.get("username"),
+            password=mwdb_config.get("password"),
+            verify_ssl=self.config.getboolean("mwdb", "verify_ssl"),
             retry_on_downtime=True,
+            use_keyring=False,
         )
-        if not mwdb.api.auth_token:
-            mwdb.login(mwdb_config["username"], mwdb_config["password"])
         return mwdb
 
     def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
From mwdblib v4.0.0 we can provide username/password via args.

Added verify_ssl option and turned off use_keyring because it might be annoying for automated service.
