### PR TITLE
Add volatile keyword

### DIFF
--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -521,6 +521,11 @@ class MWDBReporter(Karton):
         )
 
     def process(self, task: Task) -> None:
+        if task.has_payload("properties"):
+            if task.get_payload("properties").get("volatile"):
+                self.log.info("Not reporting volatile task")
+                return
+        
         object_type = task.headers["type"]
         mwdb_object: Optional[MWDBObject]
 


### PR DESCRIPTION
Following https://github.com/CERT-Polska/karton/issues/167, here's a simple support for the "volatile" keyword.
This gives users the ability to choose what tasks they don't want reported, examples of situations where you'd want that are given in the issue.