### PR TITLE
Do not reupload karton attribute to MWDB

### DIFF
--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -129,9 +129,6 @@ class MWDBReporter(Karton):
     ) -> None:
         # Add attributes
         for key, values in attributes.items():
-            if key == "karton":
-                # Omitting karton attribute
-                continue
             for value in values:
                 if (
                     key not in mwdb_object.attributes
@@ -222,6 +219,9 @@ class MWDBReporter(Karton):
             existing_object = None
 
         metadata: List[str] = []
+
+        # Filter out 'karton' attribute which should not be reuploaded
+        attributes = {k: v for k, v in attributes.items() if k != "karton"}
 
         if not existing_object:
             if self.mwdb.api.supports_version("2.6.0"):


### PR DESCRIPTION
"karton" should be filtered out before `object_uploader` call

closes #34 