### PR TITLE
Use bash instead of sh (and bump Python to 3.10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9
+FROM python:3.10-slim
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /app/service
 COPY ./requirements.txt ./requirements.txt


### PR DESCRIPTION
Per https://github.com/CERT-Polska/karton/issues/235