### PR TITLE
Remove config parents tagging, rename config field

### DIFF
--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -42,7 +42,7 @@ class MWDBReporter(Karton):
         },
         "payload": {
             "config": config data
-            "executed_sample": Resource with **original**, executable malware sample contents
+            "executed_sample": optional, Resource with **original**, executable malware sample contents
                       or identifier (hash) of object
             "parent": optional, Resource with **unpacked** sample/dump contents
                       or identifier (hash) of object
@@ -493,9 +493,7 @@ class MWDBReporter(Karton):
         sample_payload = task.get_payload("executed_sample")
         if isinstance(sample_payload, RemoteResource):
             # Upload original executed_sample file
-            uploaded = self._upload_file(
-                task, sample_payload
-            )
+            uploaded = self._upload_file(task, sample_payload)
             if uploaded:
                 _, sample = uploaded
             else:

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -42,7 +42,7 @@ class MWDBReporter(Karton):
         },
         "payload": {
             "config": config data
-            "executed_sample": optional, Resource with **original**, executable malware sample contents
+            "executed_sample": optional, Resource with **original** executable malware sample contents
                       or identifier (hash) of object
             "parent": optional, Resource with **unpacked** sample/dump contents
                       or identifier (hash) of object

--- a/karton/mwdb_reporter/mwdb_reporter.py
+++ b/karton/mwdb_reporter/mwdb_reporter.py
@@ -42,7 +42,7 @@ class MWDBReporter(Karton):
         },
         "payload": {
             "config": config data
-            "sample": Resource with **original** sample contents
+            "executed_sample": Resource with **original**, executable malware sample contents
                       or identifier (hash) of object
             "parent": optional, Resource with **unpacked** sample/dump contents
                       or identifier (hash) of object
@@ -488,13 +488,13 @@ class MWDBReporter(Karton):
                 "Found a 'store-in-gridfs' item inside a config from family: %s", family
             )
 
-        # Upload original sample
+        # Upload original executed sample
         sample: Optional[MWDBObject] = None
-        sample_payload = task.get_payload("sample")
+        sample_payload = task.get_payload("executed_sample")
         if isinstance(sample_payload, RemoteResource):
-            # Upload original sample file
+            # Upload original executed_sample file
             uploaded = self._upload_file(
-                task, task.get_payload("sample"), tags=["ripped:" + family]
+                task, sample_payload
             )
             if uploaded:
                 _, sample = uploaded
@@ -502,10 +502,8 @@ class MWDBReporter(Karton):
                 self.log.warning("Failed to upload sample for config")
 
         elif isinstance(sample_payload, str):
-            # Query original sample object hash
+            # Query original executed_sample object hash
             sample = self.mwdb.query_file(sample_payload, raise_not_found=False)
-            if sample:
-                self._add_tags(sample, ["ripped:" + family])
 
         # Upload dump that contains recognized config information
         parent: Optional[MWDBObject] = None


### PR DESCRIPTION
**Warning** - This PR introduces breaking changes in the config karton task format/behavior and should be merged/deployed at the same time as https://github.com/CERT-Polska/karton-config-extractor/pull/35

## Changes

The `sample` field in config tasks is renamed to `executed_sample`. The old name was very confusing, especially with the additional `parent` field. The current semantics should be easier to grasp:
* `executed_sample` - the sample that was executed in order to extract this specific config (optional)
* `parent` - the executable/dump that contains the necessary data for config extraction, i.e. you can run malduck on this file and get the config (optional)

Apart from that, `karton-config-extractor` now spawns tagging tasks for the `executed_sample` and `parent` on its own so we don't have to have this hacky tag appending in the reporter anymore

## Testing plan

Setup new versions of karton-config-extractor and karton-mwdb-reporter in mwdb-playground and check that each scenario behaves the same way as it does currently:

- [x] A config that is extracted from an executable - should be tagged with both `{family}` and `ripped:{family}`
- [x] A config that is extracted from a dump file (analysis) - dump should be tagged with `{family}` and the executable with `ripped:{family}`
- [x] A config without `executed_sample` and `parent` specified - repoter should still upload the config to mwdb and issue no dditional tags

